### PR TITLE
Add support for bitwise operators. 

### DIFF
--- a/OperatorToken.go
+++ b/OperatorToken.go
@@ -21,6 +21,9 @@ const (
 
 	PLUS
 	MINUS
+	BITWISE_AND
+	BITWISE_OR
+	BITWISE_XOR
 	MULTIPLY
 	DIVIDE
 	MODULUS
@@ -28,6 +31,7 @@ const (
 
 	NEGATE
 	INVERT
+	BITWISE_NOT
 
 	TERNARY_TRUE
 	TERNARY_FALSE
@@ -58,18 +62,22 @@ var LOGICAL_SYMBOLS = map[string]OperatorSymbol{
 
 var MODIFIER_SYMBOLS = map[string]OperatorSymbol{
 
-	"+": PLUS,
-	"-": MINUS,
-	"*": MULTIPLY,
-	"/": DIVIDE,
-	"%": MODULUS,
-	"^": EXPONENT,
+	"+":  PLUS,
+	"-":  MINUS,
+	"&":  BITWISE_AND,
+	"|":  BITWISE_OR,
+	"^":  BITWISE_XOR,
+	"*":  MULTIPLY,
+	"/":  DIVIDE,
+	"%":  MODULUS,
+	"**": EXPONENT,
 }
 
 var PREFIX_SYMBOLS = map[string]OperatorSymbol{
 
 	"-": NEGATE,
 	"!": INVERT,
+	"~": BITWISE_NOT,
 }
 
 var TERNARY_SYMBOLS = map[string]OperatorSymbol{
@@ -81,6 +89,10 @@ var ADDITIVE_MODIFIERS = []OperatorSymbol{
 	PLUS, MINUS,
 }
 
+var BITWISE_MODIFIERS = []OperatorSymbol{
+	BITWISE_AND, BITWISE_OR, BITWISE_XOR,
+}
+
 var MULTIPLICATIVE_MODIFIERS = []OperatorSymbol{
 	MULTIPLY, DIVIDE, MODULUS,
 }
@@ -90,7 +102,7 @@ var EXPONENTIAL_MODIFIERS = []OperatorSymbol{
 }
 
 var PREFIX_MODIFIERS = []OperatorSymbol{
-	NEGATE, INVERT,
+	NEGATE, INVERT, BITWISE_NOT,
 }
 
 var NUMERIC_COMPARATORS = []OperatorSymbol{

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Backslashes can be used anywhere in an expression to escape the very next charac
 What operators and types does this support?
 --
 
-* Modifiers: `+` `-` `/` `*` `^` `%`
+* Modifiers: `+` `-` `/` `*` `&` `|` `^` `**` `%`
 * Comparators: `>` `>=` `<` `<=` `==` `!=` `=~` `!~`
 * Logical ops: `||` `&&`
 * Numeric constants, as 64-bit floating point (`12345.678`)
@@ -157,14 +157,17 @@ Note that this table shows what each type supports - if you use an operator then
 | -                          	| Subtracts             	| **X**           	| **X**           	|
 | /                          	| Divides               	| **X**           	| **X**           	|
 | *                          	| Multiplies            	| **X**           	| **X**           	|
-| ^                          	| Takes to the power of 	| **X**           	| **X**           	|
+| &                          	| Bitwise and             | **X**           	| **X**           	|
+|\|                          	| Bitwise or              | **X**           	| **X**           	|
+| ^                          	| Bitwise xor             | **X**           	| **X**           	|
+| **                         	| Takes to the power of 	| **X**           	| **X**           	|
 | %                          	| Modulo                	| **X**           	| **X**           	|
 | Greater/Lesser (> >= < <=) 	| Valid                 	| **X**           	| **X**           	|
 | Equality (== !=)           	| Checks by value       	| Checks by value 	| Checks by value 	|
-| Ternary (? :)                 | **X**                     | **X**             | Checks by value   |
-| Regex (=~ !~)                 | **X**                     | Regex             | **X**             |
+| Ternary (? :)               | **X**                   | **X**             | Checks by value   |
+| Regex (=~ !~)               | **X**                   | Regex             | **X**             |
 | !                          	| **X**                 	| **X**           	| Inverts         	|
-| Negate (-)                 	| Multiplies by -1        	| **X**           	| **X**           	|
+| Negate (-)                 	| Multiplies by -1        | **X**           	| **X**           	|
 
 It may, at first, not make sense why a Date supports all the same things as a number. In this library, dates are treated as the unix time. That is, the number of seconds since epoch. In practice this means that sub-second precision with this library is impossible (drop an issue in Github if this is a deal-breaker for you). It also, by association, means that you can do operations that you may not expect, like taking a date to the power of two. The author sees no harm in this. Your date probably appreciates it.
 

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -39,6 +39,30 @@ func TestNoParameterEvaluation(test *testing.T) {
 		},
 		EvaluationTest{
 
+			Name:     "Single BITWISE AND",
+			Input:    "100 & 50",
+			Expected: 32.0,
+		},
+		EvaluationTest{
+
+			Name:     "Single BITWISE OR",
+			Input:    "100 | 50",
+			Expected: 118.0,
+		},
+		EvaluationTest{
+
+			Name:     "Single BITWISE XOR",
+			Input:    "100 ^ 50",
+			Expected: 86.0,
+		},
+		EvaluationTest{
+
+			Name:     "Single BITWISE NOT",
+			Input:    "~10",
+			Expected: -11.0,
+		},
+		EvaluationTest{
+
 			Name:     "Single MULTIPLY",
 			Input:    "5 * 20",
 			Expected: 100.0,
@@ -63,9 +87,21 @@ func TestNoParameterEvaluation(test *testing.T) {
 		},
 		EvaluationTest{
 
+			Name:     "Single EXPONENT",
+			Input:    "10 ** 2",
+			Expected: 100.0,
+		},
+		EvaluationTest{
+
 			Name:     "Compound PLUS",
 			Input:    "20 + 30 + 50",
 			Expected: 100.0,
+		},
+		EvaluationTest{
+
+			Name:     "Compound BITWISE AND",
+			Input:    "20 & 30 & 50",
+			Expected: 16.0,
 		},
 		EvaluationTest{
 
@@ -84,6 +120,12 @@ func TestNoParameterEvaluation(test *testing.T) {
 			Name:     "Nested parentheses",
 			Input:    "50 + (5 * (15 - 5))",
 			Expected: 100.0,
+		},
+		EvaluationTest{
+
+			Name:     "Nested parentheses with bitwise",
+			Input:    "100 ^ (23 * (2 | 5))",
+			Expected: 197.0,
 		},
 		EvaluationTest{
 
@@ -178,7 +220,7 @@ func TestNoParameterEvaluation(test *testing.T) {
 		EvaluationTest{
 
 			Name:     "Exponent precedence",
-			Input:    "1 + 5 ^ 3 % 2 * 5",
+			Input:    "1 + 5 ** 3 % 2 * 5",
 			Expected: 6.0,
 		},
 		EvaluationTest{

--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -13,7 +13,7 @@ const (
 	INVALID_TOKEN_KIND              = "Invalid token"
 	UNCLOSED_QUOTES                 = "Unclosed string literal"
 	UNCLOSED_BRACKETS               = "Unclosed parameter bracket"
-	UNBALANCED_PARENTHESIS			= "Unbalanced parenthesis"
+	UNBALANCED_PARENTHESIS          = "Unbalanced parenthesis"
 )
 
 /*
@@ -39,18 +39,6 @@ func TestParsingFailure(test *testing.T) {
 
 			Name:     "Invalid equality comparator",
 			Input:    "1 === 1",
-			Expected: INVALID_TOKEN_KIND,
-		},
-		ParsingFailureTest{
-
-			Name:     "Half of a logical operator",
-			Input:    "true & false",
-			Expected: INVALID_TOKEN_KIND,
-		},
-		ParsingFailureTest{
-
-			Name:     "Half of a logical operator",
-			Input:    "true | false",
 			Expected: INVALID_TOKEN_KIND,
 		},
 		ParsingFailureTest{


### PR DESCRIPTION
`&` (and), `|` (or), `^` (xor), and `~` (not) are now supported.

Float64 values are truncated to int64 then converted back.

The `exponent` operator is now `**`.