### PR TITLE
set value to false if parameter is not found instead of returning an error

### DIFF
--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -86,7 +86,7 @@ func TestNilParameterUsage(test *testing.T) {
 		EvaluationFailureTest{
 			Name:     "Absent parameter used",
 			Input:    "foo > 1",
-			Expected: ABSENT_PARAMETER,
+			Expected: INVALID_COMPARATOR_TYPES,
 		},
 	}
 

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -962,6 +962,18 @@ func TestParameterizedEvaluation(test *testing.T) {
 
 			Expected: "2awesome",
 		},
+		EvaluationTest{
+
+			Name:     "Absent parameter alone",
+			Input:    "[foo]",
+			Expected: false,
+		},
+		EvaluationTest{
+
+			Name:     "Negated absent parameter",
+			Input:    "! [foo]",
+			Expected: true,
+		},
 	}
 
 	runEvaluationTests(evaluationTests, test)

--- a/parameters.go
+++ b/parameters.go
@@ -1,9 +1,5 @@
 package govaluate
 
-import (
-	"errors"
-)
-
 /*
 	Parameters is a collection of named parameters that can be used by an EvaluableExpression to retrieve parameters
 	when an expression tries to use them.
@@ -24,8 +20,7 @@ func (p MapParameters) Get(name string) (interface{}, error) {
 	value, found := p[name]
 
 	if !found {
-		errorMessage := "No parameter '" + name + "' found."
-		return nil, errors.New(errorMessage)
+		return false, nil
 	}
 
 	return value, nil


### PR DESCRIPTION
This would be very useful to test the existence of a parameter.

Combined with a function like this:

```
functions := map[string]govaluate.ExpressionFunction{
		"bool": func(args ...interface{}) (interface{}, error) {
			switch args[0].(type) {
			case bool:
				return args[0].(bool), nil
			default:
				return true, nil
			}
		},
	}
```

We can write expressions like `bool([foo])` that returns true/false if foo is defined or not.

By returning an error, the possible workaround is to treat error as false but there is no way to invert the expression and I loose the feedback of an possible incorrect expression.