### PR TITLE
Intern bools to avoid allocation on bool to interface{}

### DIFF
--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -40,6 +40,11 @@ type evaluationStage struct {
 	typeErrorFormat string
 }
 
+var (
+	_true  = interface{}(true)
+	_false = interface{}(false)
+)
+
 func (this *evaluationStage) swapWith(other *evaluationStage) {
 
 	temp := *other
@@ -82,46 +87,46 @@ func modulusStage(left interface{}, right interface{}, parameters Parameters) (i
 	return math.Mod(left.(float64), right.(float64)), nil
 }
 func gteStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	if(isString(left) && isString(right)) {
-		return left.(string) >= right.(string), nil
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) >= right.(string)), nil
 	}
-	return left.(float64) >= right.(float64), nil
+	return boolIface(left.(float64) >= right.(float64)), nil
 }
 func gtStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	if(isString(left) && isString(right)) {
-		return left.(string) > right.(string), nil
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) > right.(string)), nil
 	}
-	return left.(float64) > right.(float64), nil
+	return boolIface(left.(float64) > right.(float64)), nil
 }
 func lteStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	if(isString(left) && isString(right)) {
-		return left.(string) <= right.(string), nil
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) <= right.(string)), nil
 	}
-	return left.(float64) <= right.(float64), nil
+	return boolIface(left.(float64) <= right.(float64)), nil
 }
 func ltStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	if(isString(left) && isString(right)) {
-		return left.(string) < right.(string), nil
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) < right.(string)), nil
 	}
-	return left.(float64) < right.(float64), nil
+	return boolIface(left.(float64) < right.(float64)), nil
 }
 func equalStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	return left == right, nil
+	return boolIface(left == right), nil
 }
 func notEqualStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	return left != right, nil
+	return boolIface(left != right), nil
 }
 func andStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	return left.(bool) && right.(bool), nil
+	return boolIface(left.(bool) && right.(bool)), nil
 }
 func orStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	return left.(bool) || right.(bool), nil
+	return boolIface(left.(bool) || right.(bool)), nil
 }
 func negateStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 	return -right.(float64), nil
 }
 func invertStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
-	return !right.(bool), nil
+	return boolIface(!right.(bool)), nil
 }
 func bitwiseNotStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 	return float64(^int64(right.(float64))), nil
@@ -317,4 +322,15 @@ func isArray(value interface{}) bool {
 		return true
 	}
 	return false
+}
+
+/*
+	Converting a boolean to an interface{} requires an allocation.
+	We can use interned bools to avoid this cost.
+*/
+func boolIface(b bool) interface{} {
+	if b {
+		return _true
+	}
+	return _false
 }


### PR DESCRIPTION
This doesn't affect any functionality, just reduces allocations and improves performance.

Affected benchmarks on `master`:
```
BenchmarkEvaluationNumericLiteral-8        	20000000	        79.6 ns/op	       1 B/op	       1 allocs/op
BenchmarkEvaluationLiteralModifiers-8      	10000000	       133 ns/op	      16 B/op	       2 allocs/op
BenchmarkEvaluationParameters-8            	10000000	       167 ns/op	      17 B/op	       2 allocs/op
BenchmarkEvaluationParametersModifiers-8   	 5000000	       319 ns/op	      40 B/op	       4 allocs/op
BenchmarkComplexExpression-8               	 3000000	       482 ns/op	      83 B/op	       6 allocs/op
BenchmarkConstantRegexExpression-8         	 2000000	       760 ns/op	      48 B/op	       7 allocs/op
```

Post-change:
```
BenchmarkEvaluationNumericLiteral-8        	20000000	        61.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkEvaluationLiteralModifiers-8      	20000000	       117 ns/op	       8 B/op	       1 allocs/op
BenchmarkEvaluationParameters-8            	10000000	       147 ns/op	      16 B/op	       1 allocs/op
BenchmarkEvaluationParametersModifiers-8   	 5000000	       287 ns/op	      32 B/op	       3 allocs/op
BenchmarkComplexExpression-8               	 3000000	       427 ns/op	      80 B/op	       3 allocs/op
BenchmarkConstantRegexExpression-8         	 2000000	       681 ns/op	      48 B/op	       6 allocs/op
```