### PR TITLE
Fix panic when eliding invalid constant cases

### DIFF
--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -98,6 +98,12 @@ func TestModifierTyping(test *testing.T) {
 	evaluationTests := []EvaluationFailureTest{
 		EvaluationFailureTest{
 
+			Name:     "PLUS literal number to literal bool",
+			Input:    "1 + true",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
 			Name:     "PLUS number to bool",
 			Input:    "number + bool",
 			Expected: INVALID_MODIFIER_TYPES,
@@ -242,6 +248,12 @@ func TestLogicalOperatorTyping(test *testing.T) {
 func TestComparatorTyping(test *testing.T) {
 
 	evaluationTests := []EvaluationFailureTest{
+		EvaluationFailureTest{
+
+			Name:     "GT literal bool to literal bool",
+			Input:    "true > true",
+			Expected: INVALID_COMPARATOR_TYPES,
+		},
 		EvaluationFailureTest{
 
 			Name:     "GT bool to bool",

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -658,6 +658,10 @@ func elideStage(root *evaluationStage) *evaluationStage {
 		return root
 	}
 
+	if root.typeCheck != nil && !root.typeCheck(leftValue, rightValue) {
+		return root
+	}
+
 	// pre-calculate, and return a new stage representing the result.
 	result, err = root.operator(leftValue, rightValue, nil)
 	if err != nil {


### PR DESCRIPTION
+, >, <, <=, and >= require typechecking of both operands
simultaneously; constant-operand eliding did not perform this check,
causing a panic.

In the below examples, `conditional.go` is a test program I wrote when investigating this library; it is essentially a minimal REPL for govaluate.

Before:
```
$ go run conditional.go 
> 1 > true
panic: interface conversion: interface is bool, not float64

goroutine 1 [running]:
panic(0x4e0180, 0xc42001a0c0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/Knetic/govaluate.gtStage(0x4d5ac0, 0xc42000a188, 0x4d5900, 0xc42000a198, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/repos/go/src/github.com/Knetic/govaluate/evaluationStage.go:103 +0xb7
github.com/Knetic/govaluate.elideStage(0xc4200a00f0, 0xc4200a00a0)
	/repos/go/src/github.com/Knetic/govaluate/stagePlanner.go:662 +0x254
[...]
exit status 2
```

After:
```
$ go run conditional.go 
> 1 > true
Evaluate: Value '1' cannot be used with the comparator '>', it is not a number
> 
```

The error message is still incorrect, but it's better than a panic. Likely the error message should be something along the lines of `"Values '1' and 'true' cannot be used with the comparator '>'"`.