### PR TITLE
Parsing dates using system's local time zone

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -441,7 +441,7 @@ func tryParseExactTime(candidate string, format string) (time.Time, bool) {
 	var ret time.Time
 	var err error
 
-	ret, err = time.Parse(format, candidate)
+	ret, err = time.ParseInLocation(format, candidate, time.Local)
 	if err != nil {
 		return time.Now(), false
 	}

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -63,7 +63,7 @@ func TestConstantParsing(test *testing.T) {
 			Expected: []ExpressionToken{
 				ExpressionToken{
 					Kind:  TIME,
-					Value: time.Date(2014, time.January, 2, 0, 0, 0, 0, time.UTC),
+					Value: time.Date(2014, time.January, 2, 0, 0, 0, 0, time.Local),
 				},
 			},
 		},
@@ -74,7 +74,7 @@ func TestConstantParsing(test *testing.T) {
 			Expected: []ExpressionToken{
 				ExpressionToken{
 					Kind:  TIME,
-					Value: time.Date(2014, time.January, 2, 14, 12, 0, 0, time.UTC),
+					Value: time.Date(2014, time.January, 2, 14, 12, 0, 0, time.Local),
 				},
 			},
 		},
@@ -85,7 +85,7 @@ func TestConstantParsing(test *testing.T) {
 			Expected: []ExpressionToken{
 				ExpressionToken{
 					Kind:  TIME,
-					Value: time.Date(2014, time.January, 2, 14, 12, 22, 0, time.UTC),
+					Value: time.Date(2014, time.January, 2, 14, 12, 22, 0, time.Local),
 				},
 			},
 		},

--- a/sql_test.go
+++ b/sql_test.go
@@ -69,7 +69,7 @@ func TestSQLSerialization(test *testing.T) {
 		QueryTest{
 
 			Name:     "Date format",
-			Input:    "'2014-07-04'",
+			Input:    "'2014-07-04T00:00:00Z'",
 			Expected: "'2014-07-04T00:00:00Z'",
 		},
 		QueryTest{


### PR DESCRIPTION
Following #49 discussion, this PR change date parsing from `Parse` to `ParseInLocation`. I've updated tests accordingly.