### PR TITLE
Add support for paring hex literals

### DIFF
--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -15,9 +15,10 @@ const (
 	UNCLOSED_BRACKETS               = "Unclosed parameter bracket"
 	UNBALANCED_PARENTHESIS          = "Unbalanced parenthesis"
 	INVALID_NUMERIC                 = "Unable to parse numeric value"
-	UNDEFINED_FUNCTION				= "Undefined function"
-	HANGING_ACCESSOR				= "Hanging accessor on token"
-	UNEXPORTED_ACCESSOR				= "Unable to access unexported"
+	UNDEFINED_FUNCTION              = "Undefined function"
+	HANGING_ACCESSOR                = "Hanging accessor on token"
+	UNEXPORTED_ACCESSOR             = "Unable to access unexported"
+	INVALID_HEX                     = "Unable to parse hex value"
 )
 
 /*
@@ -167,28 +168,37 @@ func TestParsingFailure(test *testing.T) {
 		},
 		ParsingFailureTest{
 
-			Name:		"Undefined function",
-			Input:		"foobar()",
-			Expected:	UNDEFINED_FUNCTION,
+			Name:     "Undefined function",
+			Input:    "foobar()",
+			Expected: UNDEFINED_FUNCTION,
 		},
 		ParsingFailureTest{
 
-			Name:		"Hanging accessor",
-			Input:		"foo.Bar.",
-			Expected:	HANGING_ACCESSOR,
+			Name:     "Hanging accessor",
+			Input:    "foo.Bar.",
+			Expected: HANGING_ACCESSOR,
 		},
 		ParsingFailureTest{
 
 			// this is expected to change once there are structtags in place that allow aliasing of fields
-			Name:		"Unexported parameter access",
-			Input:		"foo.bar",
-			Expected:	UNEXPORTED_ACCESSOR,
+			Name:     "Unexported parameter access",
+			Input:    "foo.bar",
+			Expected: UNEXPORTED_ACCESSOR,
 		},
 		ParsingFailureTest{
-
-			Name:		"Hex literal (#63)",
-			Input:		"0x10 > 0",
-			Expected:	INVALID_TOKEN_TRANSITION,
+			Name:     "Incomplete Hex",
+			Input:    "0x",
+			Expected: INVALID_TOKEN_TRANSITION,
+		},
+		ParsingFailureTest{
+			Name:     "Invalid Hex literal",
+			Input:    "0x > 0",
+			Expected: INVALID_HEX,
+		},
+		ParsingFailureTest{
+			Name:     "Hex float (Unsupported)",
+			Input:    "0x1.1",
+			Expected: INVALID_TOKEN_TRANSITION,
 		},
 	}
 

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -47,6 +47,37 @@ func TestConstantParsing(test *testing.T) {
 		},
 		TokenParsingTest{
 
+			Name:  "Zero",
+			Input: "0",
+			Expected: []ExpressionToken{
+				ExpressionToken{
+					Kind:  NUMERIC,
+					Value: 0.0,
+				},
+			},
+		},
+		TokenParsingTest{
+			Name:  "One digit hex",
+			Input: "0x1",
+			Expected: []ExpressionToken{
+				ExpressionToken{
+					Kind:  NUMERIC,
+					Value: 1.0,
+				},
+			},
+		},
+		TokenParsingTest{
+			Name:  "Two digit hex",
+			Input: "0x10",
+			Expected: []ExpressionToken{
+				ExpressionToken{
+					Kind:  NUMERIC,
+					Value: 16.0,
+				},
+			},
+		},
+		TokenParsingTest{
+
 			Name:  "Single string",
 			Input: "'foo'",
 			Expected: []ExpressionToken{
@@ -355,11 +386,11 @@ func TestConstantParsing(test *testing.T) {
 			},
 		},
 		TokenParsingTest{
-			Name:      "Double-quoted string added to square-brackted param (#59)",
-			Input:     "\"a\" + [foo]",
+			Name:  "Double-quoted string added to square-brackted param (#59)",
+			Input: "\"a\" + [foo]",
 			Expected: []ExpressionToken{
 				ExpressionToken{
-					Kind: STRING,
+					Kind:  STRING,
 					Value: "a",
 				},
 				ExpressionToken{
@@ -367,28 +398,28 @@ func TestConstantParsing(test *testing.T) {
 					Value: "+",
 				},
 				ExpressionToken{
-					Kind: VARIABLE,
+					Kind:  VARIABLE,
 					Value: "foo",
 				},
 			},
 		},
 		TokenParsingTest{
-			Name:      "Accessor variable",
-			Input:     "foo.Var",
+			Name:  "Accessor variable",
+			Input: "foo.Var",
 			Expected: []ExpressionToken{
 				ExpressionToken{
-					Kind: ACCESSOR,
-					Value: []string {"foo", "Var"},
+					Kind:  ACCESSOR,
+					Value: []string{"foo", "Var"},
 				},
 			},
 		},
 		TokenParsingTest{
-			Name:      "Accessor function",
-			Input:     "foo.Operation()",
+			Name:  "Accessor function",
+			Input: "foo.Operation()",
 			Expected: []ExpressionToken{
 				ExpressionToken{
-					Kind: ACCESSOR,
-					Value: []string {"foo", "Operation"},
+					Kind:  ACCESSOR,
+					Value: []string{"foo", "Operation"},
 				},
 				ExpressionToken{
 					Kind: CLAUSE,
@@ -1523,11 +1554,11 @@ func runTokenParsingTest(tokenParsingTests []TokenParsingTest, test *testing.T) 
 
 	fmt.Printf("Running %d parsing test cases...\n", len(tokenParsingTests))
 	// defer func() {
-    //     if r := recover(); r != nil {
-    //         test.Logf("Panic in test '%s': %v", parsingTest.Name, r)
+	//     if r := recover(); r != nil {
+	//         test.Logf("Panic in test '%s': %v", parsingTest.Name, r)
 	// 		test.Fail()
-    //     }
-    // }()
+	//     }
+	// }()
 
 	// Run the test cases.
 	for _, parsingTest = range tokenParsingTests {


### PR DESCRIPTION
Note: White space changes are an affect of running gofmt (Can remove them and re-raise the request).