### PR TITLE
- fix methods on pointer types

### DIFF
--- a/dummies_test.go
+++ b/dummies_test.go
@@ -23,6 +23,10 @@ func (this dummyParameter) Func2() (string, error) {
 	return "frink", nil
 }
 
+func (this *dummyParameter) Func3() string {
+	return "fronk"
+}
+
 func (this dummyParameter) FuncArgStr(arg1 string) string {
 	return arg1
 }

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -275,8 +275,11 @@ func makeAccessorStage(pair []string) evaluationOperator {
 
 			coreValue := reflect.ValueOf(value)
 
+			var corePtrVal reflect.Value
+
 			// if this is a pointer, resolve it.
 			if coreValue.Kind() == reflect.Ptr {
+				corePtrVal = coreValue
 				coreValue = coreValue.Elem()
 			}
 
@@ -292,7 +295,12 @@ func makeAccessorStage(pair []string) evaluationOperator {
 
 			method := coreValue.MethodByName(pair[i])
 			if method == (reflect.Value{}) {
-				return nil, errors.New("No method or field '" + pair[i] + "' present on parameter '" + pair[i-1] + "'")
+				if corePtrVal.IsValid() {
+					method = corePtrVal.MethodByName(pair[i])
+				}
+				if method == (reflect.Value{}) {
+					return nil, errors.New("No method or field '" + pair[i] + "' present on parameter '" + pair[i-1] + "'")
+				}
 			}
 
 			switch right.(type) {

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -1302,6 +1302,13 @@ func TestParameterizedEvaluation(test *testing.T) {
 		},
 		EvaluationTest{
 
+			Name:       "Simple parameter function call from pointer",
+			Input:      "fooptr.Func3()",
+			Parameters: []EvaluationParameter{fooPtrParameter},
+			Expected:   "fronk",
+		},
+		EvaluationTest{
+
 			Name:       "Simple parameter call",
 			Input:      "foo.String == 'hi'",
 			Parameters: []EvaluationParameter{fooParameter},


### PR DESCRIPTION
If you had a method on a pointer type, i.e.:

functions (f *foo) Bar() string {
	return “baz”
}

you would get the error:

No method or field ‘Bar’ present on parameter . . .

This fixes the issue.

More details here:  https://github.com/Knetic/govaluate/issues/73