### PR TITLE
Added type conversion for function input arguments

### DIFF
--- a/dummies_test.go
+++ b/dummies_test.go
@@ -2,6 +2,7 @@ package govaluate
 
 import (
 	"errors"
+	"fmt"
 )
 
 /*
@@ -29,6 +30,16 @@ func (this *dummyParameter) Func3() string {
 
 func (this dummyParameter) FuncArgStr(arg1 string) string {
 	return arg1
+}
+
+func (this dummyParameter) TestArgs(str string, ui uint, ui8 uint8, ui16 uint16, ui32 uint32, ui64 uint64, i int, i8 int8, i16 int16, i32 int32, i64 int64, f32 float32, f64 float64) string {
+	var sum float64
+	sum = float64(ui) + float64(ui8) + float64(ui16) + float64(ui32) + float64(ui64)
+	sum += float64(i) + float64(i8) + float64(i16) + float64(i32) + float64(i64)
+	sum += float64(f32)
+	sum += f64
+
+	return fmt.Sprintf("%v: %v", str, sum)
 }
 
 func (this dummyParameter) AlwaysFail() (interface{}, error) {

--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -33,9 +33,9 @@ const (
 	ABSENT_PARAMETER                = "No parameter"
 	INVALID_REGEX                   = "Unable to compile regexp pattern"
 	INVALID_PARAMETER_CALL          = "No method or field"
-	TOO_FEW_ARGS                    = "reflect: Call with too few input arguments"
-	TOO_MANY_ARGS                   = "reflect: Call with too many input arguments"
-	MISMATCHED_PARAMETERS           = "reflect: Call using"
+	TOO_FEW_ARGS                    = "Too few arguments to parameter call"
+	TOO_MANY_ARGS                   = "Too many arguments to parameter call"
+	MISMATCHED_PARAMETERS           = "Argument type conversion failed"
 )
 
 // preset parameter map of types that can be used in an evaluation failure test to check typing.

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -1330,6 +1330,14 @@ func TestParameterizedEvaluation(test *testing.T) {
 		},
 		EvaluationTest{
 
+			Name:       "Parameter function call with all argument types",
+			Input:      "foo.TestArgs(\"hello\", 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1.0, 2.0)",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   "hello: 33",
+		},
+
+		EvaluationTest{
+
 			Name:       "Simple parameter function call, one arg",
 			Input:      "foo.FuncArgStr('boop')",
 			Parameters: []EvaluationParameter{fooParameter},


### PR DESCRIPTION
 - this uses the built-in go methods to convert from one type to another
 - the main impetus was to support function calls with numeric parameters that weren’t doubles