### PR TITLE
Support nested Parameters.

### DIFF
--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -71,9 +71,12 @@ func TestNestedParameters(test *testing.T) {
 	if err != nil {
 		test.Fatal(err)
 	}
-	_, err = expression.Evaluate(parameters)
+	result, err := expression.Evaluate(parameters)
 	if err != nil {
 		test.Error(err)
+	}
+	if got, want := result.(bool), true; got != want {
+		test.Errorf("bad result: got %t, want %t", got, want)
 	}
 }
 

--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -45,6 +45,38 @@ var EVALUATION_FAILURE_PARAMETERS = map[string]interface{}{
 	"bool":   true,
 }
 
+func TestUnexportedStructParameter(test *testing.T) {
+	parameters := map[string]interface{}{
+		"foo": struct{ a string }{a: "hello"},
+	}
+	expression, err := NewEvaluableExpression(`foo.a == "hello"`)
+	if err != nil {
+		test.Fatal(err)
+	}
+	_, err = expression.Evaluate(parameters)
+	if err == nil {
+		test.Error("expected non-nil error")
+	}
+}
+
+func TestNestedParameters(test *testing.T) {
+	parameters := map[string]interface{}{
+		"foo": MapParameters{
+			"bar": MapParameters{
+				"baz": 5,
+			},
+		},
+	}
+	expression, err := NewEvaluableExpression(`foo.bar.baz == 5`)
+	if err != nil {
+		test.Fatal(err)
+	}
+	_, err = expression.Evaluate(parameters)
+	if err != nil {
+		test.Error(err)
+	}
+}
+
 func TestComplexParameter(test *testing.T) {
 
 	var expression *EvaluableExpression

--- a/parsing.go
+++ b/parsing.go
@@ -189,16 +189,6 @@ func readToken(stream *lexerStream, state lexerState, functions map[string]Expre
 				splits := strings.Split(tokenString, ".")
 				tokenValue = splits
 
-				// check that none of them are unexported
-				for i := 1; i < len(splits); i++ {
-
-					firstCharacter := getFirstRune(splits[i])
-
-					if unicode.ToUpper(firstCharacter) != firstCharacter {
-						errorMsg := fmt.Sprintf("Unable to access unexported field '%s' in token '%s'", splits[i], tokenString)
-						return ExpressionToken{}, errors.New(errorMsg), false
-					}
-				}
 			}
 			break
 		}

--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -179,13 +179,6 @@ func TestParsingFailure(test *testing.T) {
 			Expected: HANGING_ACCESSOR,
 		},
 		ParsingFailureTest{
-
-			// this is expected to change once there are structtags in place that allow aliasing of fields
-			Name:     "Unexported parameter access",
-			Input:    "foo.bar",
-			Expected: UNEXPORTED_ACCESSOR,
-		},
-		ParsingFailureTest{
 			Name:     "Incomplete Hex",
 			Input:    "0x",
 			Expected: INVALID_TOKEN_TRANSITION,


### PR DESCRIPTION
Support nested Parameters by adding a type assertion to the query
loop in evaluationStage.go. Remove the check for unexported
accessors in the parser, and replace with a check for unexported
field access in evaluationStage.

This allows nesting maps in an arbitrary fashion with the
MapParameters type, as shown by the unit test.

Fixes #70