### PR TITLE
Add parsing options, including option to skip automatic date parsing

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -11,7 +11,7 @@ import (
 	"unicode"
 )
 
-func parseTokens(expression string, functions map[string]ExpressionFunction) ([]ExpressionToken, error) {
+func parseTokens(expression string, functions map[string]ExpressionFunction, opts options) ([]ExpressionToken, error) {
 
 	var ret []ExpressionToken
 	var token ExpressionToken
@@ -25,7 +25,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 
 	for stream.canRead() {
 
-		token, err, found = readToken(stream, state, functions)
+		token, err, found = readToken(stream, state, functions, opts)
 
 		if err != nil {
 			return ret, err
@@ -52,7 +52,7 @@ func parseTokens(expression string, functions map[string]ExpressionFunction) ([]
 	return ret, nil
 }
 
-func readToken(stream *lexerStream, state lexerState, functions map[string]ExpressionFunction) (ExpressionToken, error, bool) {
+func readToken(stream *lexerStream, state lexerState, functions map[string]ExpressionFunction, opts options) (ExpressionToken, error, bool) {
 
 	var function ExpressionFunction
 	var ret ExpressionToken
@@ -214,12 +214,13 @@ func readToken(stream *lexerStream, state lexerState, functions map[string]Expre
 			stream.rewind(-1)
 
 			// check to see if this can be parsed as a time.
-			tokenTime, found = tryParseTime(tokenValue.(string))
-			if found {
-				kind = TIME
-				tokenValue = tokenTime
-			} else {
-				kind = STRING
+      kind = STRING
+      if !opts.skipDateParsing {
+        tokenTime, found = tryParseTime(tokenValue.(string))
+        if found {
+          kind = TIME
+          tokenValue = tokenTime
+        }
 			}
 			break
 		}


### PR DESCRIPTION
To support arbitrary date layout parsing, one approach would be to define a custom "parsetime" function, which would take a date/time layout as a parameter, with the same format as time.Parse():

```
	functions := map[string]govaluate.ExpressionFunction{
		"parsetime": func(args ...interface{}) (interface{}, error) {
			return time.Parse(args[0].(string), args[1].(string))
		},
	}
```

With the above function, it would be possible to evaluate the following expression:
```
parsetime('Mon Jan 2 15:04:05 2006', [ts])
```
where "ts" is a parameter. However, since govaluate always attempts to parse strings as dates, the layout ends up being parsed as a date.

I think it would be useful to provide a method to disable automatic date parsing, this may actually provide a small performance improvement as a side effect. I can work on a PR if that makes sense.