### PR TITLE
Add generic slice support for 'in' operator.

### DIFF
--- a/dummies_test.go
+++ b/dummies_test.go
@@ -9,11 +9,15 @@ import (
 	Struct used to test "parameter calls".
 */
 type dummyParameter struct {
-	String    string
-	Int       int
-	BoolFalse bool
-	Nil       interface{}
-	Nested    dummyNestedParameter
+	String      string
+	Int         int
+	BoolFalse   bool
+	Nil         interface{}
+	StringSlice []string
+	IntSlice    []int
+	FloatSlice  []float64
+	BoolSlice   []bool
+	Nested      dummyNestedParameter
 }
 
 func (this dummyParameter) Func() string {
@@ -33,9 +37,9 @@ func (this dummyParameter) FuncArgStr(arg1 string) string {
 }
 
 func (this dummyParameter) TestArgs(str string, ui uint, ui8 uint8, ui16 uint16, ui32 uint32, ui64 uint64, i int, i8 int8, i16 int16, i32 int32, i64 int64, f32 float32, f64 float64, b bool) string {
-	
+
 	var sum float64
-	
+
 	sum = float64(ui) + float64(ui8) + float64(ui16) + float64(ui32) + float64(ui64)
 	sum += float64(i) + float64(i8) + float64(i16) + float64(i32) + float64(i64)
 	sum += float64(f32)
@@ -60,10 +64,14 @@ func (this dummyNestedParameter) Dunk(arg1 string) string {
 }
 
 var dummyParameterInstance = dummyParameter{
-	String:    "string!",
-	Int:       101,
-	BoolFalse: false,
-	Nil:       nil,
+	String:      "string!",
+	Int:         101,
+	BoolFalse:   false,
+	Nil:         nil,
+	StringSlice: []string{"foo", "bar"},
+	IntSlice:    []int{1, 2, 3},
+	FloatSlice:  []float64{1.5, 3.0},
+	BoolSlice:   []bool{true},
 	Nested: dummyNestedParameter{
 		Funk: "funkalicious",
 	},

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -710,7 +710,7 @@ func TestNoParameterEvaluation(test *testing.T) {
 			Expected: true,
 		},
 		EvaluationTest{
-			
+
 			Name:  "Ternary/Java EL ambiguity",
 			Input: "false ? foo:length()",
 			Functions: map[string]ExpressionFunction{
@@ -1416,6 +1416,54 @@ func TestParameterizedEvaluation(test *testing.T) {
 
 			Name:       "Null coalesce nested parameter",
 			Input:      "foo.Nil ?? false",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "Element in string slice",
+			Input:      "'foo' in foo.StringSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "Element not in string slice",
+			Input:      "'foobar' in foo.StringSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "Element in int slice",
+			Input:      "2 in foo.IntSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "Element not in int slice",
+			Input:      "-2 in foo.IntSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "Element in float slice",
+			Input:      "1.5 in foo.FloatSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "Element not in float slice",
+			Input:      "-2.0 in foo.FloatSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "Element in bool slice",
+			Input:      "true in foo.BoolSlice",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "Element not in bool slice",
+			Input:      "false in foo.BoolSlice",
 			Parameters: []EvaluationParameter{fooParameter},
 			Expected:   false,
 		},


### PR DESCRIPTION
This commit makes the 'IN' operator more tolerant of input
datatypes; previously all 'IN' statements required []interface{}
as an input.

Now any kind of slice can be used.

Signed-off-by: Eric Chlebek <eric@sensu.io>