### PR TITLE
Add IP and IPNET support

### DIFF
--- a/TokenKind.go
+++ b/TokenKind.go
@@ -10,6 +10,8 @@ const (
 
 	PREFIX
 	NUMERIC
+	IP
+	IPNET
 	BOOLEAN
 	STRING
 	PATTERN
@@ -41,6 +43,10 @@ func (kind TokenKind) String() string {
 		return "PREFIX"
 	case NUMERIC:
 		return "NUMERIC"
+	case IP:
+		return "IP"
+	case IPNET:
+		return "IPNET"
 	case BOOLEAN:
 		return "BOOLEAN"
 	case STRING:

--- a/dummies_test.go
+++ b/dummies_test.go
@@ -3,6 +3,7 @@ package govaluate
 import (
 	"errors"
 	"fmt"
+	"net"
 )
 
 /*
@@ -14,6 +15,10 @@ type dummyParameter struct {
 	BoolFalse bool
 	Nil       interface{}
 	Nested    dummyNestedParameter
+	IP1       net.IP
+	IP2       net.IP
+	CIDR1     net.IPNet
+	CIDR2     net.IPNet
 }
 
 func (this dummyParameter) Func() string {
@@ -33,9 +38,9 @@ func (this dummyParameter) FuncArgStr(arg1 string) string {
 }
 
 func (this dummyParameter) TestArgs(str string, ui uint, ui8 uint8, ui16 uint16, ui32 uint32, ui64 uint64, i int, i8 int8, i16 int16, i32 int32, i64 int64, f32 float32, f64 float64, b bool) string {
-	
+
 	var sum float64
-	
+
 	sum = float64(ui) + float64(ui8) + float64(ui16) + float64(ui32) + float64(ui64)
 	sum += float64(i) + float64(i8) + float64(i16) + float64(i32) + float64(i64)
 	sum += float64(f32)
@@ -67,11 +72,25 @@ var dummyParameterInstance = dummyParameter{
 	Nested: dummyNestedParameter{
 		Funk: "funkalicious",
 	},
+	IP1:   net.ParseIP("127.0.0.1"),
+	IP2:   net.ParseIP("127.0.0.3"),
+	CIDR1: mustParseCIDR("127.0.0.4/22"),
+	CIDR2: mustParseCIDR("27.0.0.0/12"),
 }
 
 var fooParameter = EvaluationParameter{
 	Name:  "foo",
 	Value: dummyParameterInstance,
+}
+
+var fooParameterEmptyIP = EvaluationParameter{
+	Name: "foo",
+	Value: dummyParameter{
+		IP1:   nil,
+		IP2:   nil,
+		CIDR1: mustParseCIDR("127.0.0.4/22"),
+		CIDR2: mustParseCIDR("27.0.0.0/12"),
+	},
 }
 
 var fooPtrParameter = EvaluationParameter{
@@ -82,4 +101,29 @@ var fooPtrParameter = EvaluationParameter{
 var fooFailureParameters = map[string]interface{}{
 	"foo":    fooParameter.Value,
 	"fooptr": &fooPtrParameter.Value,
+}
+
+func mustParseCIDR(cidr string) net.IPNet {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return *ipNet
+
+}
+
+var CIDRTestFunction = map[string]ExpressionFunction{
+	"InNetwork": func(args ...interface{}) (interface{}, error) {
+		ip, ok1 := args[0].(net.IP)
+		ipNet, ok2 := args[1].(net.IPNet)
+
+		if !ok1 {
+			return nil, fmt.Errorf("variable %s not ip", args[0])
+		}
+		if !ok2 {
+			return nil, fmt.Errorf("variable %s not IPnet its %T", args[1], args[1])
+		}
+
+		return ipNet.Contains(ip), nil
+	},
 }

--- a/evaluationFailure_test.go
+++ b/evaluationFailure_test.go
@@ -6,6 +6,7 @@ package govaluate
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 )
@@ -43,6 +44,8 @@ var EVALUATION_FAILURE_PARAMETERS = map[string]interface{}{
 	"number": 1,
 	"string": "foo",
 	"bool":   true,
+	"ip":     net.ParseIP("127.0.0.1"),
+	"ipnet":  mustParseCIDR("127.0.0.1/12"),
 }
 
 func TestComplexParameter(test *testing.T) {
@@ -185,6 +188,42 @@ func TestModifierTyping(test *testing.T) {
 			Input:    "number >> bool",
 			Expected: INVALID_MODIFIER_TYPES,
 		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_RSHIFT bool to IP",
+			Input:    "bool >> ip",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_OR string to ip",
+			Input:    "string | ip",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_RSHIFT bool to ipnet",
+			Input:    "bool >> ipnet",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_OR string to ipnet",
+			Input:    "string | ipnet",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_RSHIFT number to ipnet",
+			Input:    "number >> ipnet",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "BITWISE_OR number to ipnet",
+			Input:    "number | ipnet",
+			Expected: INVALID_MODIFIER_TYPES,
+		},
 	}
 
 	runEvaluationFailureTests(evaluationTests, test)
@@ -239,6 +278,42 @@ func TestLogicalOperatorTyping(test *testing.T) {
 
 			Name:     "OR string to bool",
 			Input:    "string || bool",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "AND bool to IP",
+			Input:    "bool && ip",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "OR string to ip",
+			Input:    "string || ip",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "AND bool to ipnet",
+			Input:    "bool && ipnet",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "OR string to ipnet",
+			Input:    "string || ipnet",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "AND number to ipnet",
+			Input:    "number && ipnet",
+			Expected: INVALID_LOGICALOP_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "OR number to ipnet",
+			Input:    "number || ipnet",
 			Expected: INVALID_LOGICALOP_TYPES,
 		},
 	}
@@ -368,6 +443,18 @@ func TestComparatorTyping(test *testing.T) {
 			Input:    "1 in true",
 			Expected: INVALID_COMPARATOR_TYPES,
 		},
+		EvaluationFailureTest{
+
+			Name:     "NREQ bool to ipnet",
+			Input:    "bool !~ ipnet",
+			Expected: INVALID_COMPARATOR_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "IN string to ipnet",
+			Input:    "string in ipnet",
+			Expected: INVALID_COMPARATOR_TYPES,
+		},
 	}
 
 	runEvaluationFailureTests(evaluationTests, test)
@@ -386,6 +473,12 @@ func TestTernaryTyping(test *testing.T) {
 
 			Name:     "Ternary with string",
 			Input:    "'foo' ? true",
+			Expected: INVALID_TERNARY_TYPES,
+		},
+		EvaluationFailureTest{
+
+			Name:     "Ternary with ip",
+			Input:    "'foo' ? ip",
 			Expected: INVALID_TERNARY_TYPES,
 		},
 	}

--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -1,9 +1,11 @@
 package govaluate
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"reflect"
 	"regexp"
 	"strings"
@@ -114,11 +116,17 @@ func gteStage(left interface{}, right interface{}, parameters Parameters) (inter
 	if isString(left) && isString(right) {
 		return boolIface(left.(string) >= right.(string)), nil
 	}
+	if isIp(left) && isIp(right) {
+		return boolIface(bytes.Compare(left.(net.IP).To4(), right.(net.IP).To4()) >= 0), nil
+	}
 	return boolIface(left.(float64) >= right.(float64)), nil
 }
 func gtStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 	if isString(left) && isString(right) {
 		return boolIface(left.(string) > right.(string)), nil
+	}
+	if isIp(left) && isIp(right) {
+		return boolIface(bytes.Compare(left.(net.IP).To4(), right.(net.IP).To4()) > 0), nil
 	}
 	return boolIface(left.(float64) > right.(float64)), nil
 }
@@ -126,11 +134,17 @@ func lteStage(left interface{}, right interface{}, parameters Parameters) (inter
 	if isString(left) && isString(right) {
 		return boolIface(left.(string) <= right.(string)), nil
 	}
+	if isIp(left) && isIp(right) {
+		return boolIface(bytes.Compare(left.(net.IP).To4(), right.(net.IP).To4()) <= 0), nil
+	}
 	return boolIface(left.(float64) <= right.(float64)), nil
 }
 func ltStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 	if isString(left) && isString(right) {
 		return boolIface(left.(string) < right.(string)), nil
+	}
+	if isIp(left) && isIp(right) {
+		return boolIface(bytes.Compare(left.(net.IP).To4(), right.(net.IP).To4()) == 0), nil
 	}
 	return boolIface(left.(float64) < right.(float64)), nil
 }
@@ -421,7 +435,7 @@ func separatorStage(left interface{}, right interface{}, parameters Parameters) 
 func inStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
 
 	for _, value := range right.([]interface{}) {
-		if left == value {
+		if reflect.DeepEqual(left, value) {
 			return true, nil
 		}
 	}
@@ -437,6 +451,11 @@ func isString(value interface{}) bool {
 		return true
 	}
 	return false
+}
+
+func isIp(value interface{}) bool {
+	_, ok := value.(net.IP)
+	return ok
 }
 
 func isRegexOrString(value interface{}) bool {
@@ -493,6 +512,10 @@ func comparatorTypeCheck(left interface{}, right interface{}) bool {
 	if isString(left) && isString(right) {
 		return true
 	}
+	if isIp(left) && isIp(right) {
+		return true
+	}
+
 	return false
 }
 

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -710,7 +710,7 @@ func TestNoParameterEvaluation(test *testing.T) {
 			Expected: true,
 		},
 		EvaluationTest{
-			
+
 			Name:  "Ternary/Java EL ambiguity",
 			Input: "false ? foo:length()",
 			Functions: map[string]ExpressionFunction{
@@ -1417,6 +1417,87 @@ func TestParameterizedEvaluation(test *testing.T) {
 			Name:       "Null coalesce nested parameter",
 			Input:      "foo.Nil ?? false",
 			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "IP equal",
+			Input:      "foo.IP1 == foo.IP1",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "IP not equal",
+			Input:      "foo.IP1 != foo.IP1",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "IP greater than equal",
+			Input:      "foo.IP2 >= foo.IP1",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "IP greater than equal false result",
+			Input:      "foo.IP1 >= foo.IP2",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "IP in",
+			Input:      "foo.IP1 in (foo.IP2, 127.0.0.2, foo.IP1)",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "IP not in",
+			Input:      "foo.IP1 in (foo.IP2, 127.0.0.2)",
+			Parameters: []EvaluationParameter{fooParameter},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "CIDR in Network",
+			Input:      "InNetwork(foo.IP1, foo.CIDR1)",
+			Parameters: []EvaluationParameter{fooParameter},
+			Functions:  CIDRTestFunction,
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "CIDR not in Network",
+			Input:      "InNetwork(foo.IP1, foo.CIDR2)",
+			Parameters: []EvaluationParameter{fooParameter},
+			Functions:  CIDRTestFunction,
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "nil IP equal",
+			Input:      "foo.IP1 == 127.0.0.1",
+			Parameters: []EvaluationParameter{fooParameterEmptyIP},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "nil IP not equal",
+			Input:      "foo.IP1 != 127.0.0.1",
+			Parameters: []EvaluationParameter{fooParameterEmptyIP},
+			Expected:   true,
+		},
+		EvaluationTest{
+			Name:       "nil IP greater than equal false result",
+			Input:      "foo.IP1 >= 127.0.0.1",
+			Parameters: []EvaluationParameter{fooParameterEmptyIP},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "nil IP in",
+			Input:      "foo.IP1 in (127.0.0.1, 127.0.0.2,  127.0.0.3)",
+			Parameters: []EvaluationParameter{fooParameterEmptyIP},
+			Expected:   false,
+		},
+		EvaluationTest{
+			Name:       "nil CIDR in Network",
+			Input:      "InNetwork(foo.IP1, foo.CIDR1)",
+			Parameters: []EvaluationParameter{fooParameterEmptyIP},
+			Functions:  CIDRTestFunction,
 			Expected:   false,
 		},
 	}

--- a/lexerState.go
+++ b/lexerState.go
@@ -32,6 +32,7 @@ var validLexerStates = []lexerState{
 			STRING,
 			TIME,
 			CLAUSE,
+			IP,
 		},
 	},
 
@@ -53,6 +54,7 @@ var validLexerStates = []lexerState{
 			TIME,
 			CLAUSE,
 			CLAUSE_CLOSE,
+			IP,
 		},
 	},
 
@@ -94,8 +96,29 @@ var validLexerStates = []lexerState{
 			SEPARATOR,
 		},
 	},
-	lexerState{
 
+	lexerState{
+		kind:       IP,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+			SEPARATOR,
+			COMPARATOR,
+			CLAUSE_CLOSE,
+			LOGICALOP,
+		},
+	},
+
+	lexerState{
+		kind:       IPNET,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+			CLAUSE_CLOSE,
+		},
+	},
+
+	lexerState{
 		kind:       BOOLEAN,
 		isEOF:      true,
 		isNullable: false,
@@ -203,6 +226,7 @@ var validLexerStates = []lexerState{
 			CLAUSE,
 			CLAUSE_CLOSE,
 			PATTERN,
+			IP,
 		},
 	},
 	lexerState{
@@ -300,6 +324,8 @@ var validLexerStates = []lexerState{
 			FUNCTION,
 			ACCESSOR,
 			CLAUSE,
+			IP,
+			IPNET,
 		},
 	},
 }

--- a/parsing.go
+++ b/parsing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -106,13 +107,34 @@ func readToken(stream *lexerStream, state lexerState, functions map[string]Expre
 
 			tokenString = readTokenUntilFalse(stream, isNumeric)
 			tokenValue, err = strconv.ParseFloat(tokenString, 64)
-
-			if err != nil {
-				errorMsg := fmt.Sprintf("Unable to parse numeric value '%v' to float64\n", tokenString)
-				return ExpressionToken{}, errors.New(errorMsg), false
+			if err == nil {
+				kind = NUMERIC
+				break
 			}
-			kind = NUMERIC
-			break
+
+			tokenValue = net.ParseIP(tokenString)
+
+			if tokenValue.(net.IP) != nil {
+				tokenValue.(net.IP).String()
+				//maybe it`s CIDR?
+				if stream.canRead() {
+					stream.readCharacter()
+					tokenTail := readTokenUntilFalse(stream, isCIDRTail)
+
+					if _, ipNet, err := net.ParseCIDR(tokenString + tokenTail); err == nil {
+						kind = IPNET
+						tokenValue = *ipNet
+						break
+					}
+				}
+
+				kind = IP
+				break
+			}
+
+			errorMsg := fmt.Sprintf("Unable to parse numeric value '%v' to float64, ip cidr\n", tokenString)
+			return ExpressionToken{}, errors.New(errorMsg), false
+
 		}
 
 		// comma, separator
@@ -414,10 +436,6 @@ func checkBalance(tokens []ExpressionToken) error {
 	return nil
 }
 
-func isDigit(character rune) bool {
-	return unicode.IsDigit(character)
-}
-
 func isHexDigit(character rune) bool {
 
 	character = unicode.ToLower(character)
@@ -434,6 +452,11 @@ func isHexDigit(character rune) bool {
 func isNumeric(character rune) bool {
 
 	return unicode.IsDigit(character) || character == '.'
+}
+
+func isCIDRTail(character rune) bool {
+
+	return unicode.IsDigit(character) || character == '/'
 }
 
 func isNotQuote(character rune) bool {

--- a/parsingFailure_test.go
+++ b/parsingFailure_test.go
@@ -161,9 +161,8 @@ func TestParsingFailure(test *testing.T) {
 			Expected: UNBALANCED_PARENTHESIS,
 		},
 		ParsingFailureTest{
-
 			Name:     "Multiple radix",
-			Input:    "127.0.0.1",
+			Input:    "127.0.0.1.1.1.1.",
 			Expected: INVALID_NUMERIC,
 		},
 		ParsingFailureTest{

--- a/stagePlanner.go
+++ b/stagePlanner.go
@@ -421,6 +421,10 @@ func planValue(stream *tokenStream) (*evaluationStage, error) {
 		fallthrough
 	case PATTERN:
 		fallthrough
+	case IP:
+		fallthrough
+	case IPNET:
+		fallthrough
 	case BOOLEAN:
 		symbol = LITERAL
 		operator = makeLiteralStage(token.Value)

--- a/tokenKind_test.go
+++ b/tokenKind_test.go
@@ -28,6 +28,8 @@ func TestTokenKindStrings(test *testing.T) {
 		CLAUSE,
 		CLAUSE_CLOSE,
 		TERNARY,
+		IP,
+		IPNET,
 	}
 
 	for _, kind := range kinds {


### PR DESCRIPTION
Hi!

I`ve add support for IP and IPNET in govaluate.
Expressions like "(MYIP >= 10.10.30.30) || (InNetwork(MYIP, 10.2.2.2/20))" really useful for difficult IP matching.