### PR TITLE
add support to solve the field type implement `Parameters`.

### DIFF
--- a/evaluationStage.go
+++ b/evaluationStage.go
@@ -315,6 +315,15 @@ func makeAccessorStage(pair []string) evaluationOperator {
 
 		for i := 1; i < len(pair); i++ {
 
+			// if this is another Parameters
+			if pv, ok := value.(Parameters); ok {
+				value, err = pv.Get(pair[i])
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+
 			coreValue := reflect.ValueOf(value)
 
 			var corePtrVal reflect.Value


### PR DESCRIPTION
Hi, this library is awesome and really helps a lot.

But while I using I'm wondering to solve situation like some struct has a field of another `Parameters`, for example:

```go

type DemoParams map[string]interface{}

func (d DemoParams) Get(s string) (interface{}, error) {
	v, ok := d[s]
	if ok {
		return v, nil
	}
	return nil, fmt.Errorf("%s not exist", s)
}

sharedParams := DemoParams{
	"A":  1,
	"B": 2,
	"C": DemoParams{
		"D": 3,
               "E": DemoParams{
		       "F": 4,
               },
	},
}

expr := "A + B + C.D + C.D.E.F"
// got "1+2+3+4"
```

So I made this PR, I tried to find the test of `Parameters` but failed, so if any place can I add test please let me know.

Thanks.