### PR TITLE
null coalescence operator with inexistant param

### DIFF
--- a/EvaluableExpression.go
+++ b/EvaluableExpression.go
@@ -171,7 +171,9 @@ func (this EvaluableExpression) evaluateStage(stage *evaluationStage, parameters
 	if stage.leftStage != nil {
 		left, err = this.evaluateStage(stage.leftStage, parameters)
 		if err != nil {
-			return nil, err
+			if stage.symbol!=COALESCE { // Doesn't raise error if the parameter doesn't exists with '??' operator
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
On left side of '??' operator, it may be better to consider a not defined param as nil instead of raising an error.

Example :  if foo is not defined then `foo??'default_value'` returns 'default_value' instead of en error
