### PR TITLE
Fix evaluation_test on 32 bit architectures

### DIFF
--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -1163,7 +1163,7 @@ func TestParameterizedEvaluation(test *testing.T) {
 			Parameters: []EvaluationParameter{
 				EvaluationParameter{
 					Name:  "foo",
-					Value: 2887057409,
+					Value: int64(2887057409),
 				},
 			},
 			Expected: true,
@@ -1175,7 +1175,7 @@ func TestParameterizedEvaluation(test *testing.T) {
 			Parameters: []EvaluationParameter{
 				EvaluationParameter{
 					Name:  "foo",
-					Value: 2887057409,
+					Value: int64(2887057409),
 				},
 			},
 			Expected: true,


### PR DESCRIPTION
Before this patch this is the result on i586:

# github.com/Knetic/govaluate [github.com/Knetic/govaluate.test]
./evaluation_test.go:1166:6: constant 2887057409 overflows int
./evaluation_test.go:1178:6: constant 2887057409 overflows int
FAIL	github.com/Knetic/govaluate [build failed]