### PR TITLE
Fix BenchmarkRegexExpression this function field value does not match

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -169,14 +169,14 @@ func BenchmarkRegexExpression(bench *testing.B) {
 
 	var expressionString string
 
-	expressionString = "(foo !~ bar) && (foobar =~ oba)"
+	expressionString = "(foo !~ bar) && (baz =~ oba)"
 
 	expression, _ := NewEvaluableExpression(expressionString)
 	parameters := map[string]interface{}{
 		"foo": "foo",
 		"bar": "bar",
 		"baz": "baz",
-		"oba": ".*oba.*",
+		"oba": ".*b.*",
 	}
 
 	bench.ResetTimer()


### PR DESCRIPTION
Input:
evaluate, err := expression.Evaluate("(foo !~ bar) && (foobar =~ oba)")
Output:
No parameter 'foobar' found.